### PR TITLE
feature: improved logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,13 @@ RUN apt-get install ghostscript openjdk-8-jre-headless wget git unzip xpdf-utils
 
 WORKDIR /opt/strip-coverletter
 
+# create a worker to run the script as
+RUN useradd worker --uid 1000 --shell /bin/bash --no-create-home
+RUN chown worker .
+
+# drop privileges
+USER worker
+
 # install sejda
 RUN wget --quiet https://github.com/torakiki/sejda/releases/download/v3.2.38/sejda-console-3.2.38-bin.zip
 RUN unzip -q sejda-console-3.2.38-bin.zip && ln -s sejda-console-3.2.38 sejda

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,14 @@ WORKDIR /opt/strip-coverletter
 RUN useradd worker --uid 1000 --shell /bin/bash --no-create-home
 RUN chown worker .
 
-# drop privileges
-USER worker
-
 # install sejda
 RUN wget --quiet https://github.com/torakiki/sejda/releases/download/v3.2.38/sejda-console-3.2.38-bin.zip
 RUN unzip -q sejda-console-3.2.38-bin.zip && ln -s sejda-console-3.2.38 sejda
 ENV PATH="/opt/strip-coverletter:/opt/strip-coverletter/sejda/bin:${PATH}"
 
-COPY *.sh /opt/strip-coverletter/
+# drop privileges
+USER worker
+
+COPY --chown=1000 *.sh /opt/strip-coverletter/
 ENTRYPOINT ["/opt/strip-coverletter/strip-coverletter.sh"]
 CMD []

--- a/downsample.sh
+++ b/downsample.sh
@@ -3,21 +3,40 @@ set -e
 
 infile=$1
 outfile=$2
+duration=${3:-600} # default is 10 minutes
 
 imageres=320
 threshold=10
 
-gs \
-   -o $outfile \
-   -sDEVICE=pdfwrite \
-   -dDownsampleColorImages=true \
-   -dDownsampleGrayImages=true \
-   -dDownsampleMonoImages=true \
-   -dColorImageResolution=$imageres \
-   -dGrayImageResolution=$imageres \
-   -dMonoImageResolution=$imageres \
-   -dColorImageDownsampleThreshold=$threshold \
-   -dGrayImageDownsampleThreshold=$threshold \
-   -dMonoImageDownsampleThreshold=$threshold \
-   -dAutoRotatePages=/None \
-   $infile
+# called when this script is done
+# when last command fails a dump file is written using the given output filename
+function finish {
+    retcode=$?
+    if [[ $retcode > 0 ]]; then
+        echo "downsample failed with $retcode, cleaning up"
+        rm -f "$outfile"
+    fi
+}
+trap finish EXIT
+
+# these don't seem to help much/at all
+#   -dNumRenderingThreads=64 \
+#   -dBandBufferSpace=500000000 \
+#   -sBandListStorage=memory \
+#   -dBufferSpace=1000000000 \
+
+timeout --preserve-status $duration \
+    gs \
+       -o $outfile \
+       -sDEVICE=pdfwrite \
+       -dDownsampleColorImages=true \
+       -dDownsampleGrayImages=true \
+       -dDownsampleMonoImages=true \
+       -dColorImageResolution=$imageres \
+       -dGrayImageResolution=$imageres \
+       -dMonoImageResolution=$imageres \
+       -dColorImageDownsampleThreshold=$threshold \
+       -dGrayImageDownsampleThreshold=$threshold \
+       -dMonoImageDownsampleThreshold=$threshold \
+       -dAutoRotatePages=/None \
+       $infile

--- a/strip-coverletter-docker.sh
+++ b/strip-coverletter-docker.sh
@@ -1,19 +1,40 @@
 #!/bin/bash
 set -eu
-set -xv
+
 in=$(realpath $1)
 bname_in=${in##*/} # /foo/bar/baz.pdf = baz.pdf
 
 out=$2
+out_dir=$(dirname $out)
 bname_out=${out##*/}
 
-mkdir -p vol
+work_dir="/tmp/decap"
+logfile="$work_dir/$bname_in.log" # ll: /tmp/decap/baz.pdf.log
 
-docker run \
-    --volume $(pwd):/data \
-    --volume $in:/data/$bname_in \
-    --user $(id -u $(whoami)) \
-    strip-coverletter /data/$bname_in /data/vol/$bname_out
+mkdir -p vol $work_dir
+
+function finish {
+    retcode=$?
+    if [[ $retcode > 0 ]]; then
+        # command has failed and a dump file was created
+        # move the dump file out of vol/ into the tmp dir
+        mv vol/$bname_in.dump.tar $work_dir
+        echo "failed $retcode"
+    fi
+}
+trap finish EXIT
+
+# 20 minutes, length of PackagePOA timeout
+duration=1200
+timeout --preserve-status $duration \
+    docker run \
+        --volume $(pwd):/data \
+        --volume $in:/data/$bname_in \
+        --user $(id -u $(whoami)) \
+        strip-coverletter /data/$bname_in /data/vol/$bname_out > $logfile 2>&1
 
 # move final file to original destination    
-mv vol/$bname_out $out
+mv "vol/$bname_out" $out
+
+# remove log file
+rm "$logfile"

--- a/strip-coverletter-docker.sh
+++ b/strip-coverletter-docker.sh
@@ -11,7 +11,7 @@ bname_out=${out##*/}
 work_dir="/tmp/decap"
 logfile="$work_dir/$bname_in.log" # ll: /tmp/decap/baz.pdf.log
 
-mkdir -p vol $work_dir
+mkdir -p vol $work_dir $out_dir
 
 function finish {
     retcode=$?
@@ -19,7 +19,9 @@ function finish {
         # command has failed and a dump file was created
         # move the dump file out of vol/ into the tmp dir
         mv vol/$bname_in.dump.tar $work_dir
-        echo "failed $retcode"
+        echo "failed: $retcode"
+        echo "wrote $work_dir/$bname_in.dump.tar"
+        echo "wrote $work_dir/$bname_in.log"
     fi
 }
 trap finish EXIT
@@ -30,7 +32,6 @@ timeout --preserve-status $duration \
     docker run \
         --volume $(pwd):/data \
         --volume $in:/data/$bname_in \
-        --user $(id -u $(whoami)) \
         strip-coverletter /data/$bname_in /data/vol/$bname_out > $logfile 2>&1
 
 # move final file to original destination    

--- a/test-parallel.sh
+++ b/test-parallel.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# runs N instances in parallel
+
+set -e
+
+rm -rf ptests/
+
+pollmem () {
+    while true; do
+        # memory available as a percentage
+        awk '/MemAvailable/{free=$2} /MemTotal/{total=$2} END{print (100 - (free*100)/total)}' /proc/meminfo
+        sleep 1
+    done
+}
+
+pollmem &
+pollmem_pid=$!
+
+function finish {
+    kill $pollmem_pid
+}
+trap finish EXIT
+
+
+scl () {
+    infile=$1
+    outfile=$2
+    echo "starting $infile"
+    ./strip-coverletter-docker.sh ./tests/working-fixtures/$infile ptests/$outfile.pdf
+    echo "done $infile"
+}
+
+# give 10 seconds to establish a baseline
+sleep 10
+
+scl 2654_2_merged_1399061544.pdf 1 &
+scl 3007_1_merged_1398935138.pdf 2 &
+scl 5707_0_merged_1404262610.pdf 3 &
+scl 5781_2_merged_pdf_75858_nbs612.pdf 4 &
+scl 6605_1_merged_1417429442.pdf 5 &
+scl 7538_1_merged_1421145540.pdf 6 &
+scl 9001_1_merged_pdf_112167_nk2yfl.pdf 7 &
+scl 9257_1_merged_1424838570.pdf 8 &
+scl 9943_0_merged_1423237234.pdf 9
+
+echo "--- done ---"
+
+# another 10 to restore baseline 
+sleep 10
+
+echo "done"

--- a/test-parallel.sh
+++ b/test-parallel.sh
@@ -8,7 +8,10 @@ rm -rf ptests/
 pollmem () {
     while true; do
         # memory available as a percentage
-        awk '/MemAvailable/{free=$2} /MemTotal/{total=$2} END{print (100 - (free*100)/total)}' /proc/meminfo
+        #awk '/MemAvailable/{free=$2} /MemTotal/{total=$2} END{print (100 - (free*100)/total)}' /proc/meminfo
+
+        # memory used as megabytes
+        awk '/MemAvailable/{free=$2} /MemTotal/{total=$2} END{print ((total - free)/1024) " MB used"}' /proc/meminfo
         sleep 1
     done
 }

--- a/test-parallel.sh
+++ b/test-parallel.sh
@@ -3,8 +3,6 @@
 
 set -e
 
-rm -rf ptests/
-
 pollmem () {
     while true; do
         # memory available as a percentage
@@ -21,6 +19,7 @@ pollmem_pid=$!
 
 function finish {
     kill $pollmem_pid
+    rm -rf ptests/
 }
 trap finish EXIT
 


### PR DESCRIPTION
* strip-coverletter now prints everything to stdout and stderr, no log file
* strip-coverletter-docker now captures this output to /tmp/decap/inputname.pdf.log
* strip-coverletter now emits a 'dumpfile' on error, which is the contents of the explodeddir as well as the input pdf for debugging.
* strip-coverletter-docker ensures log and dumpfile are preserved in /tmp/decap/ on error, but cleaned up on success.
* strip-coverletter-docker will now kill the process if it takes longer than 20minutes (extreme case)
* bugfix in Dockerfile so that a worker user with uid 1000 exists to run strip-coverletter without root privileges