### PR TITLE
introduces early exit from downsample.sh if potential errors exist

### DIFF
--- a/downsample.sh
+++ b/downsample.sh
@@ -19,6 +19,9 @@ function finish {
 }
 trap finish EXIT
 
+# https://stackoverflow.com/questions/2172352
+beginswith() { case $2 in "$1"*) true;; *) false;; esac; }
+
 # reads stdout from `gs` and looks for error strings
 # exits with status 2 if one detected
 # strip-coverletter.sh catches any errors and will prefer decap over squashed
@@ -30,7 +33,7 @@ function detect_errors {
         error=""
 
         # "**** Error reading a content stream. The page may be incomplete."
-        if [[ "$line" == "**** Error: "* ]]; then
+        if beginswith $line '**** Error: '; then
             error=$line
         fi
 
@@ -42,7 +45,7 @@ function detect_errors {
         # if the value of error is not empty, fail
         if [ ! -z "$error" ]; then
             echo ""
-            echo "detected imperfect squash: $error"
+            echo "detected error string: $error"
             exit 2
         fi
     done

--- a/downsample.sh
+++ b/downsample.sh
@@ -19,6 +19,35 @@ function finish {
 }
 trap finish EXIT
 
+# reads stdout from `gs` and looks for error strings
+# exits with status 2 if one detected
+# strip-coverletter.sh catches any errors and will prefer decap over squashed
+function detect_errors {
+    while read line; do
+        echo "$line"
+
+        # reset error
+        error=""
+
+        # "**** Error reading a content stream. The page may be incomplete."
+        if [[ "$line" == "**** Error: "* ]]; then
+            error=$line
+        fi
+
+        # "Output may be incorrect."
+        if [ "$line" = "Output may be incorrect." ]; then
+            error=$line
+        fi
+
+        # if the value of error is not empty, fail
+        if [ ! -z "$error" ]; then
+            echo ""
+            echo "detected imperfect squash: $error"
+            exit 2
+        fi
+    done
+}
+
 # these don't seem to help much/at all
 #   -dNumRenderingThreads=64 \
 #   -dBandBufferSpace=500000000 \
@@ -27,7 +56,7 @@ trap finish EXIT
 
 timeout --preserve-status $duration \
     gs \
-       -o $outfile \
+       -o "$outfile" \
        -sDEVICE=pdfwrite \
        -dDownsampleColorImages=true \
        -dDownsampleGrayImages=true \
@@ -39,4 +68,4 @@ timeout --preserve-status $duration \
        -dGrayImageDownsampleThreshold=$threshold \
        -dMonoImageDownsampleThreshold=$threshold \
        -dAutoRotatePages=/None \
-       $infile
+       "$infile" | detect_errors


### PR DESCRIPTION
ticket: https://elifesciences.atlassian.net/browse/PI-676

sample output:

```
GPL Ghostscript 9.23 (2018-03-21)
Copyright (C) 2018 Artifex Software, Inc.  All rights reserved.
This software comes with NO WARRANTY: see the file PUBLIC for details.
Processing pages 1 through 78.
Page 1
Page 2
Page 3
Page 4
**** Error: detected circular reference in object number 2540

detected error string: **** Error: detected circular reference in object number 2540
downsample failed with 2, cleaning up
2018-04-30 03:03:08.869971677+00:00: - failed to write /home/luke/dev/scripts/strip-coverletter/out.pdf-squashed.pdf
2018-04-30 03:03:08.870899153+00:00: thinking ...
2018-04-30 03:03:08.871901882+00:00: - preferring decapped
2018-04-30 03:03:08.872820856+00:00: removing temporary files+dir ...
2018-04-30 03:03:08.877558962+00:00: - all done •ᴗ•
```