### PR TITLE
Push images that pass tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ elifeLibrary {
     elifeMainlineOnly {
         stage 'Push image', {
             image.push()
+            image.tag('latest').push()
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,24 @@
 elifeLibrary {
+    def commit
+    def DockerImage image
+
     stage 'Checkout', {
         checkout scm
+        commit = elifeGitRevision()
     }
 
     stage 'Build image', {
-        sh './build-image.sh'
+        sh "IMAGE_TAG=${commit} ./build-image.sh"
+        image = DockerImage.elifesciences(this, "strip-coverletter", commit)
     }
 
     stage 'Run tests', {
         elifeLocalTests './project_tests.sh'
+    }
+
+    elifeMainlineOnly {
+        stage 'Push image', {
+            image.push()
+        }
     }
 }

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 set -e
-sudo docker build --tag strip-coverletter .
+
+docker build --tag strip-coverletter .
+docker tag strip-coverletter "elifesciences/strip-coverletter:${IMAGE_TAG:-latest}"


### PR DESCRIPTION
That way we can use them in elife-bot-formula rather than rebuilding the image on every new stack