### PR TITLE
strip-coverletter-docker, changes work root from /tmp to /bot-tmp/tmp

### DIFF
--- a/strip-coverletter-docker.sh
+++ b/strip-coverletter-docker.sh
@@ -12,11 +12,11 @@ bname_out=${out##*/}
 # this is easier than modifying elife-bot code.
 tmp_dir="/tmp"
 if [ -e "/bot-tmp" ]; then
-    tmp_dir="/bot-tmp/tmp"
+    tmp_dir="/bot-tmp"
 fi
 
 work_dir_root=${3:-$tmp_dir}
-work_dir="$work_dir_root/decap" # "/tmp/decap"
+work_dir="$work_dir_root/decap" # "/tmp/decap", "/bot-tmp/decap"
 logfile="$work_dir/$bname_in.log" # "/tmp/decap/baz.pdf.log"
 
 mkdir -p vol "$work_dir" "$out_dir"

--- a/strip-coverletter-docker.sh
+++ b/strip-coverletter-docker.sh
@@ -1,24 +1,32 @@
 #!/bin/bash
 set -eu
 
-in=$(realpath $1)
-bname_in=${in##*/} # /foo/bar/baz.pdf = baz.pdf
+in=$(realpath "$1")
+bname_in=${in##*/} # "/foo/bar/baz.pdf" => "baz.pdf"
 
 out=$2
-out_dir=$(dirname $out)
+out_dir=$(dirname "$out")
 bname_out=${out##*/}
 
-work_dir="/tmp/decap"
-logfile="$work_dir/$bname_in.log" # ll: /tmp/decap/baz.pdf.log
+# lsh@2022-08-02: default to the external volume mounted at /bot-tmp, if it exists.
+# this is easier than modifying elife-bot code.
+tmp_dir="/tmp"
+if [ -e "/bot-tmp" ]; then
+    tmp_dir="/bot-tmp/tmp"
+fi
 
-mkdir -p vol $work_dir $out_dir
+work_dir_root=${3:-$tmp_dir}
+work_dir="$work_dir_root/decap" # "/tmp/decap"
+logfile="$work_dir/$bname_in.log" # "/tmp/decap/baz.pdf.log"
+
+mkdir -p vol "$work_dir" "$out_dir"
 
 function finish {
     retcode=$?
-    if [[ $retcode > 0 ]]; then
+    if [[ $retcode -gt 0 ]]; then
         # command has failed and a dump file was created
         # move the dump file out of vol/ into the tmp dir
-        mv vol/$bname_in.dump.tar $work_dir
+        mv "vol/$bname_in.dump.tar" "$work_dir"
         echo "failed: $retcode"
         echo "wrote $work_dir/$bname_in.dump.tar"
         echo "wrote $work_dir/$bname_in.log"
@@ -30,12 +38,12 @@ trap finish EXIT
 duration=1200
 timeout --preserve-status $duration \
     docker run \
-        --volume $(pwd):/data \
-        --volume $in:/data/$bname_in \
-        strip-coverletter /data/$bname_in /data/vol/$bname_out > $logfile 2>&1
+        --volume "$(pwd):/data" \
+        --volume "$in:/data/$bname_in" \
+        strip-coverletter "/data/$bname_in" "/data/vol/$bname_out" > "$logfile" 2>&1
 
 # move final file to original destination    
-mv -f "vol/$bname_out" $out
+mv -f "vol/$bname_out" "$out"
 
 # remove log file
 rm -f "$logfile"


### PR DESCRIPTION
but only if /bot-tmp exists.