### PR TITLE
strip-coverletter-docker, removes the '-it' flags

### DIFF
--- a/strip-coverletter-docker.sh
+++ b/strip-coverletter-docker.sh
@@ -69,7 +69,7 @@ timeout --preserve-status $duration \
 # output files must be owned by the calling (host) user. got the idea here:
 # https://stackoverflow.com/questions/26500270/understanding-user-file-ownership-in-docker-how-to-avoid-changing-permissions-o/26514736#answer-54317162
 docker run \
-    --rm -it \
+    --rm \
     --user root \
     --entrypoint "/bin/sh" \
     --env HOST_UID=$(id -u) \

--- a/strip-coverletter.sh
+++ b/strip-coverletter.sh
@@ -68,7 +68,7 @@ function finish {
         tar -cf $dumpfile $explodeddir
         errcho "wrote $dumpfile"
     fi
-    #exit $1 # $1 wasn't always present, $? uses the return code of last run cmd
+    #exit $1 # don't do this, retcode is preserved.
 }
 trap finish EXIT
 


### PR DESCRIPTION
this causes the error 'the input device is not a TTY' in elife-bot